### PR TITLE
[CoreBundle] Fix parameter type issue in migration

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
@@ -40,7 +40,7 @@ final class Version20201208105207 extends AbstractMigration
 
             $this->updateAdjustment(
                 (int) $adjustment['id'],
-                $adjustment['shipping_id'] ?? 'NULL',
+                (string) ($adjustment['shipping_id'] ?? 'NULL'),
                 $this->getParsedDetails(['taxRateCode' => $adjustment['tax_rate_code'], 'taxRateName' => $adjustment['tax_rate_name'], 'taxRateAmount' => ($adjustment['tax_rate_amount'] ? (float) $adjustment['tax_rate_amount'] : null), 'shippingMethodCode' => $adjustment['shipment_code'], 'shippingMethodName' => $this->getShippingMethodName($adjustment['shipment_code'])])
             );
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

The shipment_id happens to be of type integer and causes a type error:

`Sylius\Bundle\CoreBundle\Migrations\Version20201208105207::updateAdjustment(): Argument #2 ($shipmentId) must be of type string, int given`

This ensures the argument to be a string in any case.